### PR TITLE
Fix snapshot test in App

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,16 +1,13 @@
 import React, { Component } from 'react';
-import './App.css';
+import PropTypes from 'prop-types';
 import CardsContainer from './CardsContainer';
-import DistrictRepository from './helper';
-import kinderData from './data/kindergartners_in_full_day_program';
-
-
+import './App.css';
 
 class App extends Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     this.state = {
-      districts: new DistrictRepository(kinderData)
+      districts: props.districts
     };
 
   }
@@ -23,5 +20,9 @@ class App extends Component {
     );
   }
 }
+
+App.propTypes = {
+  districts: PropTypes.objectOf(PropTypes.object).isRequired
+};
 
 export default App;

--- a/src/__tests__/unit/App.test.js
+++ b/src/__tests__/unit/App.test.js
@@ -1,31 +1,83 @@
-// import React from 'react';
-// import ReactDOM from 'react-dom';
-// import App from '../../App';
-// import kinderData from '../../data/kindergartners_in_full_day_program';
-// import DistrictRepository from '../../helper';
-// import {shallow, mount} from 'enzyme';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import App from '../../App';
+import {shallow} from 'enzyme';
 
-// describe('App', () => {
-//   let app;
+describe('App', () => {
+  let app;
 
-//   beforeEach(() => {
-//     app = shallow(<App />);
-//   });
+  const districts = {
+    stats: {
+      'ASPEN 1': {
+        location: 'ASPEN 1',
+        stats: {
+          '2004': 0.302,
+          '2005': 0.267,
+          '2006': 0.354,
+          '2007': 0.392,
+          '2008': 0.385,
+          '2009': 0.39,
+          '2010': 0.436,
+          '2011': 0.489,
+          '2012': 0.479,
+          '2013': 0.488,
+          '2014': 0.49
+        }
+      },
+      "PRIMERO REORGANIZED 2": {
+        location: 'PRIMERO REORGANIZED 2',
+        stats: {
+          '2004': 0.302,
+          '2005': 0.267,
+          '2006': 0.354,
+          '2007': 0.392,
+          '2008': 0.385,
+          '2009': 0.39,
+          '2010': 0.436,
+          '2011': 0.489,
+          '2012': 0.479,
+          '2013': 0.488,
+          '2014': 0.49
+        }
+      },
+      'OTIS R-3': {
+        location: 'OTIS R-3',
+        stats: {
+          '2004': 0.302,
+          '2005': 0.267,
+          '2006': 0.354,
+          '2007': 0.392,
+          '2008': 0.385,
+          '2009': 0.39,
+          '2010': 0.436,
+          '2011': 0.489,
+          '2012': 0.479,
+          '2013': 0.488,
+          '2014': 0.49
+        }
+      }                  
+    }
+  };
 
-//   it('renders without crashing', () => {
-//     const div = document.createElement('div');
 
-//     ReactDOM.render(<App />, div);
-//   });
+  beforeEach(() => {
+    app = shallow(<App districts={districts}/>);
+  });
 
-//   it('should render the fucking app', () => {
-//     app = mount(<App />);
-//     expect(app).toMatchSnapshot();
-//   });
 
-//   it('should hold an object of district data in state', () => {
-//     expect(app.state('districts')).toEqual(new DistrictRepository(kinderData));
-//   });
-  
-// });
+  it('renders without crashing', () => {
+    const div = document.createElement('div');
+
+    ReactDOM.render(<App districts={districts} />, div);
+  });
+
+  it('should render the app', () => {
+    expect(app).toMatchSnapshot();
+  });
+
+  it('should hold an object of district data in state', () => {
+    expect(app.state('districts')).toBeDefined();
+  });
+});
+
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import DistrictRepository from './helper';
+import kinderData from './data/kindergartners_in_full_day_program';
+import App from './App';
 import './index.css';
 
-import App from './App';
+const kindergartnersInFullDayProgram = new DistrictRepository(kinderData);
 
-ReactDOM.render( <App />, document.getElementById('root') );
+ReactDOM.render(
+  <App districts={kindergartnersInFullDayProgram} />,
+  document.getElementById('root')
+);


### PR DESCRIPTION
Updated description of test.
Added districts as Prop to App to facilitate testing. We can revert back to instantiating the district repository in the App constructor at a later time if needed.